### PR TITLE
Lockfree + Faster instant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ coarsetime = ["dep:coarsetime"]
 [[bench]]
 name = "log_hz_benchmarks"
 harness = false
+
+[[bench]]
+name = "log_hz_coarsetime_benchmark"
+harness = false
+required-features = ["coarsetime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,16 @@ log = "0.4"
 
 [dev-dependencies]
 testing_logger = "0.1"
+criterion = { version = "0.6.0", features = ["html_reports"] }
+rayon = "1.10.0"
+minstant = "0.1.7"
+libc = "0.2"
+coarsetime = "0.1"
+
+[features]
+default = []
+lockfree = []
+
+[[bench]]
+name = "log_hz_benchmarks"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,15 @@ categories = ["development-tools::debugging"]
 
 [dependencies]
 log = "0.4"
+coarsetime = { version = "0.1", optional = true }
 
 [dev-dependencies]
 testing_logger = "0.1"
 criterion = { version = "0.6.0", features = ["html_reports"] }
-rayon = "1.10.0"
-minstant = "0.1.7"
-libc = "0.2"
-coarsetime = "0.1"
 
 [features]
 default = []
-lockfree = []
+coarsetime = ["dep:coarsetime"]
 
 [[bench]]
 name = "log_hz_benchmarks"

--- a/benches/log_hz_benchmarks.rs
+++ b/benches/log_hz_benchmarks.rs
@@ -1,0 +1,311 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use log_hz::*;
+use rayon::prelude::*;
+use std::sync::LazyLock;
+
+// Original mutex-based log_hz macro for comparison
+macro_rules! log_hz_mutex {
+    ($level:expr, $rate:expr, $($arg:tt)+) => {
+        {
+            static TIC: std::sync::Mutex<Option<std::time::Instant>> = std::sync::Mutex::new(None);
+            static INTERVAL: std::sync::LazyLock<std::time::Duration> = std::sync::LazyLock::new(|| std::time::Duration::from_secs_f32(1.0 / ($rate as f32)));
+            let mut tick = TIC.lock().expect("log_hz mutex was poisoned, this should never happen");
+            match *tick {
+                None => {
+                    *tick = Some(std::time::Instant::now());
+                    log!($level, $($arg)+);
+                },
+                Some(ref mut tick) => {
+                    let now = std::time::Instant::now();
+                    let time_since_last = now.duration_since(*tick);
+                    if time_since_last > *INTERVAL {
+                        *tick = now;
+                        log!($level, $($arg)+);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// New lock-free log_hz macro
+macro_rules! log_hz_lockfree {
+    ($level:expr, $rate:expr, $($arg:tt)+) => {
+        {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            use std::sync::LazyLock;
+            use std::time::Instant;
+
+            static START_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+            static INTERVAL_NS: LazyLock<u64> = LazyLock::new(|| {
+                let rate_f64 = $rate as f64;
+                if rate_f64 > 0.0 {
+                    (1.0 / rate_f64 * 1_000_000_000.0) as u64
+                } else {
+                    0
+                }
+            });
+
+            static LAST_LOG_NS: AtomicU64 = AtomicU64::new(0);
+
+            let last_ns = LAST_LOG_NS.load(Ordering::Relaxed);
+            let now = Instant::now();
+            let elapsed_ns = now.duration_since(*START_TIME).as_nanos() as u64;
+
+            if elapsed_ns.saturating_sub(last_ns) >= *INTERVAL_NS {
+                if LAST_LOG_NS.compare_exchange(last_ns, elapsed_ns, Ordering::AcqRel, Ordering::Relaxed).is_ok() {
+                    log!($level, $($arg)+);
+                }
+            }
+        }
+    };
+}
+
+// A second version of the lock-free macro for benchmarking
+macro_rules! log_hz_lockfree_v2 {
+    ($level:expr, $rate:expr, $($arg:tt)+) => {
+        {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            use std::sync::LazyLock;
+            use std::time::Instant;
+
+            static START_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+            static INTERVAL_NS: LazyLock<u64> = LazyLock::new(|| {
+                let rate_f64 = $rate as f64;
+                if rate_f64 > 0.0 {
+                    (1.0 / rate_f64 * 1_000_000_000.0) as u64
+                } else {
+                    u64::MAX
+                }
+            });
+
+            static LAST_LOG_NS: AtomicU64 = AtomicU64::new(0);
+
+            let mut last_ns = LAST_LOG_NS.load(Ordering::Relaxed);
+            let now = Instant::now();
+            let elapsed_ns = now.duration_since(*START_TIME).as_nanos() as u64;
+
+            if elapsed_ns.saturating_sub(last_ns) >= *INTERVAL_NS {
+                loop {
+                    match LAST_LOG_NS.compare_exchange_weak(
+                        last_ns,
+                        elapsed_ns,
+                        Ordering::Acquire,
+                        Ordering::Relaxed,
+                    ) {
+                        Ok(_) => {
+                            log!($level, $($arg)+);
+                            break;
+                        }
+                        Err(current_ns) => {
+                            // Check if another thread already logged
+                            if elapsed_ns.saturating_sub(current_ns) < *INTERVAL_NS {
+                                break;
+                            }
+                            last_ns = current_ns;
+                        }
+                    }
+                }
+            }
+        }
+    };
+}
+
+
+// Ultra-fast version using TSC (Time Stamp Counter) via minstant
+macro_rules! log_hz_lockfree_v5 {
+    ($level:expr, $rate:expr, $($arg:tt)+) => {
+        {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            use std::sync::LazyLock;
+            use minstant::Instant;
+
+            static START_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
+            static INTERVAL_NS: LazyLock<u64> = LazyLock::new(|| {
+                let rate_f64 = $rate as f64;
+                if rate_f64 > 0.0 {
+                    (1.0 / rate_f64 * 1_000_000_000.0) as u64
+                } else {
+                    u64::MAX
+                }
+            });
+            static LAST_LOG_NS: AtomicU64 = AtomicU64::new(0);
+
+            // Use TSC-based timing - ultra fast
+            let now = Instant::now();
+            let elapsed_ns = now.duration_since(*START_TIME).as_nanos() as u64;
+            
+            let last_ns = LAST_LOG_NS.load(Ordering::Relaxed);
+            
+            // Fast path: early exit
+            if elapsed_ns.saturating_sub(last_ns) < *INTERVAL_NS {
+                return;
+            }
+
+            // Single atomic update attempt
+            if LAST_LOG_NS.compare_exchange(
+                last_ns, 
+                elapsed_ns, 
+                Ordering::AcqRel, 
+                Ordering::Relaxed
+            ).is_ok() {
+                log!($level, $($arg)+);
+            }
+        }
+    };
+}
+
+// Ultra-fast version using coarsetime (CLOCK_MONOTONIC_COARSE on Linux)
+macro_rules! log_hz_lockfree_coarsetime {
+    ($level:expr, $rate:expr, $($arg:tt)+) => {
+        {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            use std::sync::LazyLock;
+            use coarsetime::Instant;
+
+            static START_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
+            static INTERVAL_NS: LazyLock<u64> = LazyLock::new(|| {
+                let rate_f64 = $rate as f64;
+                if rate_f64 > 0.0 {
+                    (1.0 / rate_f64 * 1_000_000_000.0) as u64
+                } else {
+                    u64::MAX
+                }
+            });
+            static LAST_LOG_NS: AtomicU64 = AtomicU64::new(0);
+
+            // Use coarsetime - ultra fast coarse-grained timing
+            let now = Instant::now();
+            let elapsed_ns = now.duration_since(*START_TIME).as_nanos() as u64;
+            
+            let last_ns = LAST_LOG_NS.load(Ordering::Relaxed);
+            
+            // Fast path: early exit
+            if elapsed_ns.saturating_sub(last_ns) < *INTERVAL_NS {
+                return;
+            }
+
+            // Single atomic update attempt
+            if LAST_LOG_NS.compare_exchange(
+                last_ns, 
+                elapsed_ns, 
+                Ordering::AcqRel, 
+                Ordering::Relaxed
+            ).is_ok() {
+                log!($level, $($arg)+);
+            }
+        }
+    };
+}
+
+// Mock logger for benchmarking
+struct MockLogger;
+
+impl log::Log for MockLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, _record: &log::Record) {
+        // Do nothing - we're just measuring the macro overhead
+    }
+
+    fn flush(&self) {}
+}
+
+// Set up logger once at the beginning
+static LOGGER: LazyLock<MockLogger> = LazyLock::new(|| {
+    let logger = MockLogger;
+    // Try to set the logger, but don't panic if it's already set
+    let _ = log::set_logger(Box::leak(Box::new(logger)));
+    log::set_max_level(log::LevelFilter::Trace);
+    MockLogger
+});
+
+fn setup_logger() {
+    // Just access the static logger to ensure it's initialized
+    let _ = &*LOGGER;
+}
+
+// Helper for coarse monotonic time (Linux only)
+#[inline(always)]
+fn now_monotonic_coarse_ns() -> u64 {
+    use libc::{clock_gettime, timespec, CLOCK_MONOTONIC_COARSE};
+    let mut ts = timespec { tv_sec: 0, tv_nsec: 0 };
+    let ret = unsafe { clock_gettime(CLOCK_MONOTONIC_COARSE, &mut ts) };
+    debug_assert_eq!(ret, 0);
+    (ts.tv_sec as u64) * 1_000_000_000 + (ts.tv_nsec as u64)
+}
+
+fn benchmark_mutex_vs_lockfree(c: &mut Criterion) {
+    setup_logger();
+    
+    let mut group = c.benchmark_group("log_hz_mutex_vs_lockfree");
+    
+    // Benchmark mutex-based version
+    group.bench_function("mutex_version", |b| {
+        b.iter(|| {
+            log_hz_mutex!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
+        });
+    });
+    
+    // Benchmark lock-free version
+    group.bench_function("lockfree_version", |b| {
+        b.iter(|| {
+            log_hz_lockfree!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
+        });
+    });
+
+    group.bench_function("lockfree_version_v2", |b| {
+        b.iter(|| {
+            log_hz_lockfree_v2!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
+        });
+    });
+
+    group.bench_function("lockfree_version_v5", |b| {
+        b.iter(|| {
+            log_hz_lockfree_v5!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
+        });
+    });
+
+    group.bench_function("lockfree_version_coarsetime", |b| {
+        b.iter(|| {
+            log_hz_lockfree_coarsetime!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
+        });
+    });
+    
+    group.finish();
+}
+
+fn benchmark_concurrent_access(c: &mut Criterion) {
+    setup_logger();
+    
+    let mut group = c.benchmark_group("concurrent_access");
+    
+    // Benchmark single-threaded performance
+    group.bench_function("single_threaded", |b| {
+        b.iter(|| {
+            log_hz_lockfree!(log::Level::Info, 1.0, "Single thread message {}", black_box(42));
+        });
+    });
+    
+    // Benchmark multi-threaded performance
+    group.bench_function("multi_threaded", |b| {
+        b.iter(|| {
+            (0..100).into_par_iter().for_each(|_| {
+                log_hz_lockfree!(log::Level::Info, 1.0, "Multi thread message {}", black_box(42));
+            })
+        });
+    });
+    
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_mutex_vs_lockfree,
+    benchmark_concurrent_access,
+);
+criterion_main!(benches); 

--- a/benches/log_hz_benchmarks.rs
+++ b/benches/log_hz_benchmarks.rs
@@ -1,6 +1,6 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use log_hz::*;
-use std::sync::LazyLock;
+use std::{hint::black_box, sync::LazyLock};
 
 // Original mutex-based log_hz macro for comparison
 macro_rules! log_hz_mutex {
@@ -79,5 +79,5 @@ fn benchmark_mutex_vs_lockfree(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, benchmark_mutex_vs_lockfree,);
+criterion_group!(benches, benchmark_mutex_vs_lockfree);
 criterion_main!(benches);

--- a/benches/log_hz_benchmarks.rs
+++ b/benches/log_hz_benchmarks.rs
@@ -1,6 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use log_hz::*;
-use rayon::prelude::*;
 use std::sync::LazyLock;
 
 // Original mutex-based log_hz macro for comparison
@@ -27,179 +26,6 @@ macro_rules! log_hz_mutex {
         }
     }
 }
-
-// New lock-free log_hz macro
-macro_rules! log_hz_lockfree {
-    ($level:expr, $rate:expr, $($arg:tt)+) => {
-        {
-            use std::sync::atomic::{AtomicU64, Ordering};
-            use std::sync::LazyLock;
-            use std::time::Instant;
-
-            static START_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
-
-            static INTERVAL_NS: LazyLock<u64> = LazyLock::new(|| {
-                let rate_f64 = $rate as f64;
-                if rate_f64 > 0.0 {
-                    (1.0 / rate_f64 * 1_000_000_000.0) as u64
-                } else {
-                    0
-                }
-            });
-
-            static LAST_LOG_NS: AtomicU64 = AtomicU64::new(0);
-
-            let last_ns = LAST_LOG_NS.load(Ordering::Relaxed);
-            let now = Instant::now();
-            let elapsed_ns = now.duration_since(*START_TIME).as_nanos() as u64;
-
-            if elapsed_ns.saturating_sub(last_ns) >= *INTERVAL_NS {
-                if LAST_LOG_NS.compare_exchange(last_ns, elapsed_ns, Ordering::AcqRel, Ordering::Relaxed).is_ok() {
-                    log!($level, $($arg)+);
-                }
-            }
-        }
-    };
-}
-
-// A second version of the lock-free macro for benchmarking
-macro_rules! log_hz_lockfree_v2 {
-    ($level:expr, $rate:expr, $($arg:tt)+) => {
-        {
-            use std::sync::atomic::{AtomicU64, Ordering};
-            use std::sync::LazyLock;
-            use std::time::Instant;
-
-            static START_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
-
-            static INTERVAL_NS: LazyLock<u64> = LazyLock::new(|| {
-                let rate_f64 = $rate as f64;
-                if rate_f64 > 0.0 {
-                    (1.0 / rate_f64 * 1_000_000_000.0) as u64
-                } else {
-                    u64::MAX
-                }
-            });
-
-            static LAST_LOG_NS: AtomicU64 = AtomicU64::new(0);
-
-            let mut last_ns = LAST_LOG_NS.load(Ordering::Relaxed);
-            let now = Instant::now();
-            let elapsed_ns = now.duration_since(*START_TIME).as_nanos() as u64;
-
-            if elapsed_ns.saturating_sub(last_ns) >= *INTERVAL_NS {
-                loop {
-                    match LAST_LOG_NS.compare_exchange_weak(
-                        last_ns,
-                        elapsed_ns,
-                        Ordering::Acquire,
-                        Ordering::Relaxed,
-                    ) {
-                        Ok(_) => {
-                            log!($level, $($arg)+);
-                            break;
-                        }
-                        Err(current_ns) => {
-                            // Check if another thread already logged
-                            if elapsed_ns.saturating_sub(current_ns) < *INTERVAL_NS {
-                                break;
-                            }
-                            last_ns = current_ns;
-                        }
-                    }
-                }
-            }
-        }
-    };
-}
-
-
-// Ultra-fast version using TSC (Time Stamp Counter) via minstant
-macro_rules! log_hz_lockfree_v5 {
-    ($level:expr, $rate:expr, $($arg:tt)+) => {
-        {
-            use std::sync::atomic::{AtomicU64, Ordering};
-            use std::sync::LazyLock;
-            use minstant::Instant;
-
-            static START_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
-            static INTERVAL_NS: LazyLock<u64> = LazyLock::new(|| {
-                let rate_f64 = $rate as f64;
-                if rate_f64 > 0.0 {
-                    (1.0 / rate_f64 * 1_000_000_000.0) as u64
-                } else {
-                    u64::MAX
-                }
-            });
-            static LAST_LOG_NS: AtomicU64 = AtomicU64::new(0);
-
-            // Use TSC-based timing - ultra fast
-            let now = Instant::now();
-            let elapsed_ns = now.duration_since(*START_TIME).as_nanos() as u64;
-            
-            let last_ns = LAST_LOG_NS.load(Ordering::Relaxed);
-            
-            // Fast path: early exit
-            if elapsed_ns.saturating_sub(last_ns) < *INTERVAL_NS {
-                return;
-            }
-
-            // Single atomic update attempt
-            if LAST_LOG_NS.compare_exchange(
-                last_ns, 
-                elapsed_ns, 
-                Ordering::AcqRel, 
-                Ordering::Relaxed
-            ).is_ok() {
-                log!($level, $($arg)+);
-            }
-        }
-    };
-}
-
-// Ultra-fast version using coarsetime (CLOCK_MONOTONIC_COARSE on Linux)
-macro_rules! log_hz_lockfree_coarsetime {
-    ($level:expr, $rate:expr, $($arg:tt)+) => {
-        {
-            use std::sync::atomic::{AtomicU64, Ordering};
-            use std::sync::LazyLock;
-            use coarsetime::Instant;
-
-            static START_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
-            static INTERVAL_NS: LazyLock<u64> = LazyLock::new(|| {
-                let rate_f64 = $rate as f64;
-                if rate_f64 > 0.0 {
-                    (1.0 / rate_f64 * 1_000_000_000.0) as u64
-                } else {
-                    u64::MAX
-                }
-            });
-            static LAST_LOG_NS: AtomicU64 = AtomicU64::new(0);
-
-            // Use coarsetime - ultra fast coarse-grained timing
-            let now = Instant::now();
-            let elapsed_ns = now.duration_since(*START_TIME).as_nanos() as u64;
-            
-            let last_ns = LAST_LOG_NS.load(Ordering::Relaxed);
-            
-            // Fast path: early exit
-            if elapsed_ns.saturating_sub(last_ns) < *INTERVAL_NS {
-                return;
-            }
-
-            // Single atomic update attempt
-            if LAST_LOG_NS.compare_exchange(
-                last_ns, 
-                elapsed_ns, 
-                Ordering::AcqRel, 
-                Ordering::Relaxed
-            ).is_ok() {
-                log!($level, $($arg)+);
-            }
-        }
-    };
-}
-
 // Mock logger for benchmarking
 struct MockLogger;
 
@@ -229,83 +55,29 @@ fn setup_logger() {
     let _ = &*LOGGER;
 }
 
-// Helper for coarse monotonic time (Linux only)
-#[inline(always)]
-fn now_monotonic_coarse_ns() -> u64 {
-    use libc::{clock_gettime, timespec, CLOCK_MONOTONIC_COARSE};
-    let mut ts = timespec { tv_sec: 0, tv_nsec: 0 };
-    let ret = unsafe { clock_gettime(CLOCK_MONOTONIC_COARSE, &mut ts) };
-    debug_assert_eq!(ret, 0);
-    (ts.tv_sec as u64) * 1_000_000_000 + (ts.tv_nsec as u64)
-}
+use crate::log_hz;
 
 fn benchmark_mutex_vs_lockfree(c: &mut Criterion) {
     setup_logger();
-    
+
     let mut group = c.benchmark_group("log_hz_mutex_vs_lockfree");
-    
+
     // Benchmark mutex-based version
     group.bench_function("mutex_version", |b| {
         b.iter(|| {
             log_hz_mutex!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
         });
     });
-    
+
     // Benchmark lock-free version
     group.bench_function("lockfree_version", |b| {
         b.iter(|| {
-            log_hz_lockfree!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
+            log_hz!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
         });
     });
 
-    group.bench_function("lockfree_version_v2", |b| {
-        b.iter(|| {
-            log_hz_lockfree_v2!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
-        });
-    });
-
-    group.bench_function("lockfree_version_v5", |b| {
-        b.iter(|| {
-            log_hz_lockfree_v5!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
-        });
-    });
-
-    group.bench_function("lockfree_version_coarsetime", |b| {
-        b.iter(|| {
-            log_hz_lockfree_coarsetime!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
-        });
-    });
-    
     group.finish();
 }
 
-fn benchmark_concurrent_access(c: &mut Criterion) {
-    setup_logger();
-    
-    let mut group = c.benchmark_group("concurrent_access");
-    
-    // Benchmark single-threaded performance
-    group.bench_function("single_threaded", |b| {
-        b.iter(|| {
-            log_hz_lockfree!(log::Level::Info, 1.0, "Single thread message {}", black_box(42));
-        });
-    });
-    
-    // Benchmark multi-threaded performance
-    group.bench_function("multi_threaded", |b| {
-        b.iter(|| {
-            (0..100).into_par_iter().for_each(|_| {
-                log_hz_lockfree!(log::Level::Info, 1.0, "Multi thread message {}", black_box(42));
-            })
-        });
-    });
-    
-    group.finish();
-}
-
-criterion_group!(
-    benches,
-    benchmark_mutex_vs_lockfree,
-    benchmark_concurrent_access,
-);
-criterion_main!(benches); 
+criterion_group!(benches, benchmark_mutex_vs_lockfree,);
+criterion_main!(benches);

--- a/benches/log_hz_coarsetime_benchmark.rs
+++ b/benches/log_hz_coarsetime_benchmark.rs
@@ -1,0 +1,49 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use log_hz::*;
+use std::{hint::black_box, sync::LazyLock};
+
+// Mock logger for benchmarking
+struct MockLogger;
+
+impl log::Log for MockLogger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, _record: &log::Record) {
+        // Do nothing - we're just measuring the macro overhead
+    }
+
+    fn flush(&self) {}
+}
+
+// Set up logger once at the beginning
+static LOGGER: LazyLock<MockLogger> = LazyLock::new(|| {
+    let logger = MockLogger;
+    // Try to set the logger, but don't panic if it's already set
+    let _ = log::set_logger(Box::leak(Box::new(logger)));
+    log::set_max_level(log::LevelFilter::Trace);
+    MockLogger
+});
+
+fn setup_logger() {
+    // Just access the static logger to ensure it's initialized
+    let _ = &*LOGGER;
+}
+
+fn benchmark_lockfree_coarsetime(c: &mut Criterion) {
+    setup_logger();
+
+    let mut group = c.benchmark_group("log_hz_mutex_vs_lockfree");
+
+    // Benchmark coarsetime version
+    group.bench_function("lockfree_version_coarsetime", |b| {
+        b.iter(|| {
+            log_hz!(log::Level::Info, 1.0, "Benchmark message {}", black_box(42));
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_lockfree_coarsetime);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,69 +85,192 @@
 
 pub use log::*;
 
-/// Log a message at [Level::Error] at a throttled rate, first call will always log.
-#[macro_export]
-macro_rules! error_hz {
-    ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Error, $rate, $($arg)+); }
-}
+// Original mutex-based implementation
+#[cfg(not(feature = "lockfree"))]
+mod mutex_impl {
+    use super::*;
 
-/// Log a message at [Level::Warn] at a throttled rate, first call will always log.
-#[macro_export]
-macro_rules! warn_hz {
-    ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Warn, $rate, $($arg)+); }
-}
+    /// Log a message at [Level::Error] at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! error_hz {
+        ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Error, $rate, $($arg)+); }
+    }
 
-/// Log a message at [Level::Info] at a throttled rate, first call will always log.
-#[macro_export]
-macro_rules! info_hz {
-    ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Info, $rate, $($arg)+); }
-}
+    /// Log a message at [Level::Warn] at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! warn_hz {
+        ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Warn, $rate, $($arg)+); }
+    }
 
-/// Log a message at [Level::Debug] at a throttled rate, first call will always log.
-#[macro_export]
-macro_rules! debug_hz {
-    ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Debug, $rate, $($arg)+); }
-}
+    /// Log a message at [Level::Info] at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! info_hz {
+        ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Info, $rate, $($arg)+); }
+    }
 
-/// Log a message at [Level::Trace] at a throttled rate, first call will always log.
-#[macro_export]
-macro_rules! trace_hz {
-    ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Trace, $rate, $($arg)+); }
-}
+    /// Log a message at [Level::Debug] at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! debug_hz {
+        ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Debug, $rate, $($arg)+); }
+    }
 
-/// Log a message at the specified level at a throttled rate, first call will always log.
-#[macro_export]
-macro_rules! log_hz {
-    ($level:expr, $rate:expr, $($arg:tt)+) => {
-        // Need an inner scope to hide variables
-        {
-            // Each invocation of the macro gets its own static variable in a private scope
-            // Mutex<Option<Instant>> so we can initialize it lazily, and mutate it safely
-            // TODO there is almost certainly a faster way to do this, but this is fully safe
-            static TIC: std::sync::Mutex<Option<std::time::Instant>> = std::sync::Mutex::new(None);
-            // Using LazyLock to cache the interval calculation
-            static INTERVAL: std::sync::LazyLock<std::time::Duration> = std::sync::LazyLock::new(|| std::time::Duration::from_secs_f32(1.0 / ($rate as f32)));
-            let mut tick = TIC.lock().expect("log_hz mutex was poisoned, this should never happen");
-            match *tick {
-                // If we haven't logged before, log and set the tick
-                None => {
-                    *tick = Some(std::time::Instant::now());
-                    $crate::log!($level, $($arg)+);
-                },
-                // If we have logged before, check the interval
-                Some(ref mut tick) => {
-                    let now = std::time::Instant::now();
-                    let time_since_last = now.duration_since(*tick);
-                    if time_since_last > *INTERVAL {
-                        // If it's been long enough, log and update the tick
-                        *tick = now;
+    /// Log a message at [Level::Trace] at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! trace_hz {
+        ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Trace, $rate, $($arg)+); }
+    }
+
+    /// Log a message at the specified level at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! log_hz {
+        ($level:expr, $rate:expr, $($arg:tt)+) => {
+            // Need an inner scope to hide variables
+            {
+                // Each invocation of the macro gets its own static variable in a private scope
+                // Mutex<Option<Instant>> so we can initialize it lazily, and mutate it safely
+                // TODO there is almost certainly a faster way to do this, but this is fully safe
+                static TIC: std::sync::Mutex<Option<std::time::Instant>> = std::sync::Mutex::new(None);
+                // Using LazyLock to cache the interval calculation
+                static INTERVAL: std::sync::LazyLock<std::time::Duration> = std::sync::LazyLock::new(|| std::time::Duration::from_secs_f32(1.0 / ($rate as f32)));
+                let mut tick = TIC.lock().expect("log_hz mutex was poisoned, this should never happen");
+                match *tick {
+                    // If we haven't logged before, log and set the tick
+                    None => {
+                        *tick = Some(std::time::Instant::now());
                         $crate::log!($level, $($arg)+);
+                    },
+                    // If we have logged before, check the interval
+                    Some(ref mut tick) => {
+                        let now = std::time::Instant::now();
+                        let time_since_last = now.duration_since(*tick);
+                        if time_since_last > *INTERVAL {
+                            // If it's been long enough, log and update the tick
+                            *tick = now;
+                            $crate::log!($level, $($arg)+);
+                        }
                     }
                 }
             }
         }
     }
 }
+
+// Lock-free implementation
+#[cfg(feature = "lockfree")]
+mod lockfree_impl {
+    use super::*;
+
+    /// Log a message at [Level::Error] at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! error_hz {
+        ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Error, $rate, $($arg)+); }
+    }
+
+    /// Log a message at [Level::Warn] at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! warn_hz {
+        ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Warn, $rate, $($arg)+); }
+    }
+
+    /// Log a message at [Level::Info] at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! info_hz {
+        ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Info, $rate, $($arg)+); }
+    }
+
+    /// Log a message at [Level::Debug] at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! debug_hz {
+        ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Debug, $rate, $($arg)+); }
+    }
+
+    /// Log a message at [Level::Trace] at a throttled rate, first call will always log.
+    #[macro_export]
+    macro_rules! trace_hz {
+        ($rate:expr,$($arg:tt)+) => { $crate::log_hz!($crate::Level::Trace, $rate, $($arg)+); }
+    }
+
+    /// Log a message at the specified level at a throttled rate, first call will always log.
+    /// 
+    /// This version uses an AtomicU64 and a compare-and-swap loop to manage the throttling in a lock-free manner.
+    /// It provides better performance than the mutex-based version, especially under high contention.
+    #[macro_export]
+    macro_rules! log_hz {
+        ($level:expr, $rate:expr, $($arg:tt)+) => {
+            // Inner scope to encapsulate static variables
+            {
+                use std::sync::atomic::{AtomicU64, Ordering};
+                use std::sync::LazyLock;
+                use std::time::{Duration, Instant};
+
+                // A shared, static start time for the process.
+                // Using LazyLock ensures it's initialized only once.
+                static START_TIME: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+                // The interval between log messages in nanoseconds.
+                // Calculated once and cached. Handles cases where the rate is <= 0.
+                static INTERVAL_NS: LazyLock<u64> = LazyLock::new(|| {
+                    let rate_f64 = $rate as f64;
+                    // If rate is positive, calculate the interval. Otherwise, interval is 0,
+                    // meaning we should try to log on every call.
+                    if rate_f64 > 0.0 {
+                        (1.0 / rate_f64 * 1_000_000_000.0) as u64
+                    } else {
+                        0
+                    }
+                });
+
+                // The timestamp of the last log, stored as nanoseconds since START_TIME.
+                // Initialized to 0, which ensures the first log message always gets through.
+                static LAST_LOG_NS: AtomicU64 = AtomicU64::new(0);
+
+                // --- Fast Path ---
+                // This is the most common path, executed on every call to the macro.
+                // It's designed to be as cheap as possible.
+
+                // First, perform a quick, optimistic check to see if we should log.
+                // We use `Relaxed` ordering because it's the cheapest, and we're not
+                // yet synchronizing memory. We just want to bail out early if possible.
+                let last_ns = LAST_LOG_NS.load(Ordering::Relaxed);
+                let now = Instant::now();
+                let elapsed_ns = now.duration_since(*START_TIME).as_nanos() as u64;
+
+                // Check if enough time has passed since the last log.
+                // `saturating_sub` prevents a panic in the rare case of time moving backward.
+                if elapsed_ns.saturating_sub(last_ns) >= *INTERVAL_NS {
+                    // --- Slow Path ---
+                    // We might get to log. Now we need to ensure only one thread does.
+                    // We use a `compare_exchange` to atomically update the timestamp.
+                    // This operation attempts to replace `last_ns` with `elapsed_ns` only if
+                    // the current value is still `last_ns`.
+                    //
+                    // Ordering::AcqRel (Acquire-Release):
+                    //   - If successful, this creates a memory barrier that ensures:
+                    //     1. (Acquire) Any writes from other threads that happened before are visible now.
+                    //     2. (Release) The log message we are about to write will be visible to
+                    //        other threads that later access this atomic variable.
+                    // Ordering::Relaxed (on failure):
+                    //   - If we fail, it means another thread won the race. We don't need to
+                    //     synchronize memory, so we use the cheapest ordering.
+                    if LAST_LOG_NS.compare_exchange(last_ns, elapsed_ns, Ordering::AcqRel, Ordering::Relaxed).is_ok() {
+                        // We successfully updated the timestamp, so we have the "right" to log.
+                        $crate::log!($level, $($arg)+);
+                    }
+                    // If the `compare_exchange` failed, another thread logged in the tiny
+                    // window between our `load` and `compare_exchange`. We simply do nothing,
+                    // which correctly throttles the message.
+                }
+            }
+        };
+    }
+}
+
+// Default to mutex implementation if no feature is specified
+#[cfg(not(feature = "lockfree"))]
+pub use mutex_impl::*;
+
+#[cfg(feature = "lockfree")]
+pub use lockfree_impl::*;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Used atomic var to store timestamp in nanosecond. Also I have added new feature to use coarsetime which is 5x faster than normal instant. Majority of performance gain comes from using faster instant.

```log
log_hz_mutex_vs_lockfree/lockfree_version_coarsetime
                        time:   [8.1911 ns 8.5743 ns 9.1030 ns]
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe

log_hz_mutex_vs_lockfree/mutex_version
                        time:   [42.129 ns 42.278 ns 42.458 ns]
                        change: [−0.3395% +0.0368% +0.4176%] (p = 0.86 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe
  
log_hz_mutex_vs_lockfree/lockfree_version
                        time:   [31.278 ns 32.591 ns 34.390 ns]
                        change: [+1.4293% +4.0472% +7.6982%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
  ```